### PR TITLE
2.1.0 Localization overwrite for custom workshop languages

### DIFF
--- a/LocalizationUtilities/BuildInfo.cs
+++ b/LocalizationUtilities/BuildInfo.cs
@@ -6,6 +6,6 @@ public static class BuildInfo
 	public const string Description = "A utility mod for localized text."; // Description for the Mod.  (Set as null if none)
 	public const string Author = "ds5678, STBlade"; // Author of the Mod.  (MUST BE SET)
 	public const string Company = null; // Company that made the Mod.  (Set as null if none)
-	public const string Version = "2.0.1"; // Version of the Mod.  (MUST BE SET)
+	public const string Version = "2.1.0"; // Version of the Mod.  (MUST BE SET)
 	public const string DownloadLink = null; // Download Link for the Mod.  (Set as null if none)
 }

--- a/LocalizationUtilities/LocalizationPatch.cs
+++ b/LocalizationUtilities/LocalizationPatch.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Il2Cpp;
+using System.Text.RegularExpressions;
 using StringTableEntry = Il2Cpp.StringTableData.Entry;
 
 namespace LocalizationUtilities;
@@ -27,11 +28,19 @@ internal static class LocalizationPatch
 			for (int i = 0; i < languages.Length; i++)
 			{
 				string language = languages[i];
-				if (entry.Map.TryGetValue(language, out string? text) && !string.IsNullOrWhiteSpace(text))
+
+                string pattern = @"\[(.*?)\]";
+                Match match = Regex.Match(language, pattern);
+                if (match.Success)
+                {
+                    language = match.Groups[1].Value;
+                }
+
+                if (entry.Map.TryGetValue(language, out string? text) && !string.IsNullOrWhiteSpace(text))
 				{
 					stringEntry.m_Languages[i] = text;
-				}
-				else if (set.DefaultToEnglish && entry.Map.TryGetValue("English", out string? text2))
+				}                
+                else if (set.DefaultToEnglish && entry.Map.TryGetValue("English", out string? text2))
 				{
 					stringEntry.m_Languages[i] = text2;
 				}


### PR DESCRIPTION
Added overwrite tag for custom workshop languages. 

Problem:
"Russian by Someone" defaults to English mod localization because it won't get recognized as "Russian". 

Solution:
Renaming of custom language on the workshop to "[Russian] Russian by Someone". 
Tag [] overwrites the recognized custom game language.