### PR TITLE
changed fallback logic

### DIFF
--- a/LocalizationUtilities/BuildInfo.cs
+++ b/LocalizationUtilities/BuildInfo.cs
@@ -6,6 +6,6 @@ public static class BuildInfo
 	public const string Description = "A utility mod for localized text."; // Description for the Mod.  (Set as null if none)
 	public const string Author = "ds5678, STBlade"; // Author of the Mod.  (MUST BE SET)
 	public const string Company = null; // Company that made the Mod.  (Set as null if none)
-	public const string Version = "2.1.0"; // Version of the Mod.  (MUST BE SET)
+	public const string Version = "2.1.1"; // Version of the Mod.  (MUST BE SET)
 	public const string DownloadLink = null; // Download Link for the Mod.  (Set as null if none)
 }

--- a/LocalizationUtilities/LocalizationUtilities.csproj
+++ b/LocalizationUtilities/LocalizationUtilities.csproj
@@ -45,7 +45,7 @@
 	<!--This is the of packages that the mod references.-->
 	<ItemGroup>
 		<!--This package contains almost everything a person could possibly need to reference while modding.-->
-		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.30.0" />
+		<PackageReference Include="STBlade.Modding.TLD.Il2CppAssemblies.Windows" Version="2.40.0" />
 		<!--The package version here in this template may be outdated and need to be updated. Visual Studio can update package versions automatically.-->
 		<!--If the mod references any other mods (such as ModSettings), that NuGet package will also need to be listed here.-->
 	</ItemGroup>


### PR DESCRIPTION
Hinterland has full English fallback table available at all times. This adds English localizations to the fallback table instead of directly to current language table, when current language is not English